### PR TITLE
aes-256 암복호화 컨버터

### DIFF
--- a/src/main/kotlin/com/sendy/support/util/Aes256Converter.kt
+++ b/src/main/kotlin/com/sendy/support/util/Aes256Converter.kt
@@ -5,13 +5,6 @@ import jakarta.persistence.Converter
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
-/**
- * packageName    : com.sendy.support.util
- * fileName       : Aes256Converter
- * author         : okdori
- * date           : 2025. 7. 17.
- * description    :
- */
 @Component
 @Converter
 class Aes256Converter(

--- a/src/main/kotlin/com/sendy/support/util/Aes256Converter.kt
+++ b/src/main/kotlin/com/sendy/support/util/Aes256Converter.kt
@@ -1,0 +1,29 @@
+package com.sendy.support.util
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * packageName    : com.sendy.support.util
+ * fileName       : Aes256Converter
+ * author         : okdori
+ * date           : 2025. 7. 17.
+ * description    :
+ */
+@Component
+@Converter
+class Aes256Converter(
+    @Value("\${aes256.key}") private val key: String
+) : AttributeConverter<String, String> {
+    private val aesUtil = Aes256Util(key)
+
+    override fun convertToDatabaseColumn(attribute: String?): String? {
+        return attribute?.let { aesUtil.encrypt(it) }
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): String? {
+        return dbData?.let { aesUtil.decrypt(it) }
+    }
+}

--- a/src/main/kotlin/com/sendy/support/util/Aes256Util.kt
+++ b/src/main/kotlin/com/sendy/support/util/Aes256Util.kt
@@ -6,13 +6,6 @@ import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
-/**
- * packageName    : com.sendy.support.util
- * fileName       : Aes256Util
- * author         : okdori
- * date           : 2025. 7. 17.
- * description    :
- */
 class Aes256Util(key: String) {
     private val secretKey: SecretKeySpec
 

--- a/src/main/kotlin/com/sendy/support/util/Aes256Util.kt
+++ b/src/main/kotlin/com/sendy/support/util/Aes256Util.kt
@@ -1,0 +1,57 @@
+package com.sendy.support.util
+
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * packageName    : com.sendy.support.util
+ * fileName       : Aes256Util
+ * author         : okdori
+ * date           : 2025. 7. 17.
+ * description    :
+ */
+class Aes256Util(key: String) {
+    private val secretKey: SecretKeySpec
+
+    init {
+        require(key.length == 32) { "AES-256 알고리즘 사용 시 32바이트 키가 필수입니다." }
+        secretKey = SecretKeySpec(key.toByteArray(), ALGORITHM)
+    }
+
+    fun encrypt(plainText: String): String {
+        return try {
+            val iv = ByteArray(IV_SIZE)
+            SecureRandom().nextBytes(iv)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, IvParameterSpec(iv))
+            val encrypted = cipher.doFinal(plainText.toByteArray())
+            val ivAndEncrypted = iv + encrypted
+            Base64.getEncoder().encodeToString(ivAndEncrypted)
+        } catch (e: Exception) {
+            throw RuntimeException("AES encryption error", e)
+        }
+    }
+
+    fun decrypt(cipherText: String): String {
+        return try {
+            val ivAndEncrypted = Base64.getDecoder().decode(cipherText)
+            val iv = ivAndEncrypted.copyOfRange(0, IV_SIZE)
+            val encrypted = ivAndEncrypted.copyOfRange(IV_SIZE, ivAndEncrypted.size)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, IvParameterSpec(iv))
+            val decrypted = cipher.doFinal(encrypted)
+            String(decrypted)
+        } catch (e: Exception) {
+            throw RuntimeException("AES decryption error", e)
+        }
+    }
+
+    companion object {
+        private const val ALGORITHM = "AES"
+        private const val TRANSFORMATION = "AES/CBC/PKCS5Padding"
+        private const val IV_SIZE = 16
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,7 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+
+# 추후 Secrets Manager 등으로 이관
+aes256:
+  key: d2f3de5ce2bef6aad4c2b01e2bffdcd66190b4ed811e4e862c2f39c01ac53db5

--- a/src/test/kotlin/com/sendy/support/util/Aes256ConverterTest.kt
+++ b/src/test/kotlin/com/sendy/support/util/Aes256ConverterTest.kt
@@ -4,13 +4,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
-/**
- * packageName    : com.sendy.support.util
- * fileName       : Aes256ConverterTest
- * author         : okdori
- * date           : 2025. 7. 17.
- * description    :
- */
 class Aes256ConverterTest {
     private val key = "12345678901234567890123456789012"
     private val converter = Aes256Converter(key)

--- a/src/test/kotlin/com/sendy/support/util/Aes256ConverterTest.kt
+++ b/src/test/kotlin/com/sendy/support/util/Aes256ConverterTest.kt
@@ -1,0 +1,31 @@
+package com.sendy.support.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * packageName    : com.sendy.support.util
+ * fileName       : Aes256ConverterTest
+ * author         : okdori
+ * date           : 2025. 7. 17.
+ * description    :
+ */
+class Aes256ConverterTest {
+    private val key = "12345678901234567890123456789012"
+    private val converter = Aes256Converter(key)
+
+    @Test
+    fun `DB 저장시 암호화, 조회시 복호화가 정상 동작해야 한다`() {
+        val original = "테스트 문자열_123-!@#"
+        val encrypted = converter.convertToDatabaseColumn(original)
+        val decrypted = converter.convertToEntityAttribute(encrypted)
+        assertEquals(original, decrypted)
+    }
+
+    @Test
+    fun `null 값은 그대로 반환해야 한다`() {
+        assertNull(converter.convertToDatabaseColumn(null))
+        assertNull(converter.convertToEntityAttribute(null))
+    }
+}

--- a/src/test/kotlin/com/sendy/support/util/Aes256UtilTest.kt
+++ b/src/test/kotlin/com/sendy/support/util/Aes256UtilTest.kt
@@ -4,13 +4,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
-/**
- * packageName    : com.sendy.support.util
- * fileName       : Aes256UtilTest
- * author         : okdori
- * date           : 2025. 7. 17.
- * description    :
- */
 class Aes256UtilTest {
     private val key = "12345678901234567890123456789012"
     private val aesUtil = Aes256Util(key)

--- a/src/test/kotlin/com/sendy/support/util/Aes256UtilTest.kt
+++ b/src/test/kotlin/com/sendy/support/util/Aes256UtilTest.kt
@@ -1,0 +1,40 @@
+package com.sendy.support.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * packageName    : com.sendy.support.util
+ * fileName       : Aes256UtilTest
+ * author         : okdori
+ * date           : 2025. 7. 17.
+ * description    :
+ */
+class Aes256UtilTest {
+    private val key = "12345678901234567890123456789012"
+    private val aesUtil = Aes256Util(key)
+
+    @Test
+    fun `암호화 후 복호화하면 원본과 같아야 한다`() {
+        val original = "테스트 문자열_123-!@#"
+        val encrypted = aesUtil.encrypt(original)
+        val decrypted = aesUtil.decrypt(encrypted)
+        assertEquals(original, decrypted)
+    }
+
+    @Test
+    fun `같은 평문은 암호문이 매번 달라진다`() {
+        val text = "same text 123 !@#"
+        val encrypted1 = aesUtil.encrypt(text)
+        val encrypted2 = aesUtil.encrypt(text)
+        assert(encrypted1 != encrypted2)
+    }
+
+    @Test
+    fun `복호화에 잘못된 값이 들어오면 예외가 발생한다`() {
+        assertThrows(RuntimeException::class.java) {
+            aesUtil.decrypt("잘못된 값")
+        }
+    }
+}


### PR DESCRIPTION
- aes-256 알고리즘을 이용한 암/복호화 유틸 추가
- 암/복호화 유틸을 사용한 컨버터 추가
- 테스트 코드 추가
- 추후 릴리즈 시, yml의 작성한 민감한 정보 삭제  

컨버터 사용 방법:
- 암/복호화가 필요한 컬럼에 어노테이션 추가
```kotlin
@Entity
class Account(
    @Convert(converter = Aes256Converter::class)
    val account: String
)
``` 


#SENDY-5-4