### PR TITLE
마스킹 유틸

### DIFF
--- a/src/main/kotlin/com/sendy/support/util/MaskingUtil.kt
+++ b/src/main/kotlin/com/sendy/support/util/MaskingUtil.kt
@@ -1,0 +1,21 @@
+package com.sendy.support.util
+
+object MaskingUtil {
+    fun maskName(name: String): String {
+        if (name.isEmpty()) return ""
+        if (name.length == 1) return name
+        if (name.length == 2) return name.first() + "*"
+        return name.first() + "*".repeat(name.length - 2) + name.last()
+    }
+
+    fun maskPhone(phone: String): String {
+        // 010-1234-5678 형식 기준, 가운데 4자리 마스킹
+        val regex = Regex("(\\d{3})-(\\d{4})-(\\d{4})")
+        return phone.replace(regex, "$1-****-$3")
+    }
+
+    fun maskAccount(account: String): String {
+        if (account.length <= 4) return account
+        return "*".repeat(account.length - 4) + account.takeLast(4)
+    }
+}

--- a/src/test/kotlin/com/sendy/support/util/MaskingUtilTest.kt
+++ b/src/test/kotlin/com/sendy/support/util/MaskingUtilTest.kt
@@ -1,0 +1,36 @@
+package com.sendy.support.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MaskingUtilTest {
+    @Test
+    fun `이름 마스킹`() {
+        assertEquals("홍*동", MaskingUtil.maskName("홍길동"))
+        assertEquals("원*", MaskingUtil.maskName("원빈"))
+        assertEquals("이", MaskingUtil.maskName("이"))
+        assertEquals("김*", MaskingUtil.maskName("김민"))
+        assertEquals("", MaskingUtil.maskName(""))
+    }
+
+    @Test
+    fun `휴대폰 번호 마스킹`() {
+        assertEquals("010-****-5678", MaskingUtil.maskPhone("010-1234-5678"))
+        assertEquals("011-****-1234", MaskingUtil.maskPhone("011-9999-1234"))
+        assertEquals("010-****-0000", MaskingUtil.maskPhone("010-1111-0000"))
+        assertEquals("01012345678", MaskingUtil.maskPhone("01012345678"))
+        assertEquals("", MaskingUtil.maskPhone(""))
+    }
+
+    @Test
+    fun `계좌번호 마스킹`() {
+        assertEquals("**********1234", MaskingUtil.maskAccount("12345678901234"))
+        assertEquals("****5678", MaskingUtil.maskAccount("12345678"))
+        assertEquals("**3478", MaskingUtil.maskAccount("123478"))
+        assertEquals("1234", MaskingUtil.maskAccount("1234"))
+        assertEquals("12", MaskingUtil.maskAccount("12"))
+        assertEquals("*****6789", MaskingUtil.maskAccount("123456789"))
+        assertEquals("******7890", MaskingUtil.maskAccount("1234567890"))
+        assertEquals("*******8901", MaskingUtil.maskAccount("12345678901"))
+    }
+}


### PR DESCRIPTION
- 이름, 번호, 계좌번호 마스킹 유틸 추가
- 테스트 코드 추가

규칙 : 
이름
- 한 글자: 그대로 노출
- 두 글자: 첫 글자만 노출, 두 번째 글자는 로 마스킹 (예: 김민 → 김)
- 세 글자 이상: 첫 글자와 마지막 글자만 노출, 가운데는 로 마스킹 (예: 홍길동 → 홍*동)

휴대폰 번호
- 010-1234-5678 형식 기준, 가운데 4자리를 로 마스킹 (예: 010-***-5678)
- 하이픈(-) 없는 경우는 마스킹하지 않음

계좌번호
- 4자리 이하: 그대로 노출
- 5자리 이상: 맨 뒤 4자리만 노출, 앞부분은 모두 *로 마스킹 (예: 12345678901234 → ************1234)

#SENDY-5-13