### PR TITLE
계좌 생성 api 13자리 서버에서 생성 / 계좌비밀번호 4자리 

### DIFF
--- a/src/main/kotlin/com/sendy/application/dto/account/CreateAccountDto.kt
+++ b/src/main/kotlin/com/sendy/application/dto/account/CreateAccountDto.kt
@@ -1,10 +1,11 @@
 package com.sendy.application.dto.account
 
 data class CreateAccountRequest(
-    val accountNumber: String,
+    //val accountNumber: String, 서버에서 생상하기 때문에 더이상 request로 받지 않아도 됩니다.
     val userId: Long,
     val isPrimary: Boolean,
     val isLimitedAccount: Boolean,
+    val password: Int,
 )
 
 data class CreateAccountResponse(

--- a/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountNumberImpl.kt
+++ b/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountNumberImpl.kt
@@ -12,9 +12,6 @@ class CreateAccountNumberImpl(
     override fun generate():String {
         var accountNumber = generateAccountNumber()
 
-        while(accountRepository.existsByAccountNumber(accountNumber)){
-            accountNumber = generateAccountNumber()
-        }
         return accountNumber
     }
 

--- a/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountNumberImpl.kt
+++ b/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountNumberImpl.kt
@@ -22,11 +22,9 @@ class CreateAccountNumberImpl(
         var random = Random.Default
 
         //예시 앞 3자리 기관코드 321-xxxx-xx-xxxx [기관코드는 erdcloud에 예시로가져왔습니다.)
-        var part1 ="321"
-        var part2 = random.nextInt(1000, 10000).toString().padStart(4, '0')
-        var part3 = random.nextInt(10, 100).toString().padStart(2, '0')
-        var part4 = random.nextInt(1000, 10000).toString().padStart(4, '0')
+        val prefix ="321"
+        val body = (1..11).map{('0'..'9').random() }.joinToString("")
 
-        return "$part1$part2$part3$part4"
+        return prefix + random
     }
 }

--- a/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountNumberImpl.kt
+++ b/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountNumberImpl.kt
@@ -1,0 +1,32 @@
+package com.sendy.application.usecase.account.command
+
+import com.sendy.domain.account.AccountRepository
+import org.springframework.stereotype.Component
+import kotlin.random.Random
+
+@Component
+class CreateAccountNumberImpl(
+    private val accountRepository: AccountRepository
+) : CreateAccountNumberUseCase{
+
+    override fun generate():String {
+        var accountNumber = generateAccountNumber()
+
+        while(accountRepository.existsByAccountNumber(accountNumber)){
+            accountNumber = generateAccountNumber()
+        }
+        return accountNumber
+    }
+
+    private fun generateAccountNumber():String {
+        var random = Random.Default
+
+        //예시 앞 3자리 기관코드 321-xxxx-xx-xxxx [기관코드는 erdcloud에 예시로가져왔습니다.)
+        var part1 ="321"
+        var part2 = random.nextInt(1000, 10000).toString().padStart(4, '0')
+        var part3 = random.nextInt(10, 100).toString().padStart(2, '0')
+        var part4 = random.nextInt(1000, 10000).toString().padStart(4, '0')
+
+        return "$part1$part2$part3$part4"
+    }
+}

--- a/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountNumberUseCase.kt
+++ b/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountNumberUseCase.kt
@@ -1,0 +1,5 @@
+package com.sendy.application.usecase.account.command
+
+interface CreateAccountNumberUseCase {
+    fun generate():String
+}

--- a/src/main/kotlin/com/sendy/domain/account/AccountEntity.kt
+++ b/src/main/kotlin/com/sendy/domain/account/AccountEntity.kt
@@ -19,6 +19,9 @@ class AccountEntity(
     @Column(name = "user_id", nullable = false)
     val userId: Long,
 
+    @Column(name = "password", nullable = false, length = 4)
+    val password: Int,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     var status: AccountStatus,

--- a/src/main/kotlin/com/sendy/domain/account/AccountRepository.kt
+++ b/src/main/kotlin/com/sendy/domain/account/AccountRepository.kt
@@ -10,6 +10,4 @@ interface AccountRepository : JpaRepository<AccountEntity, Long> {
         userId: Long,
         accountNumber: String,
     ): AccountEntity?
-
-    fun existsByAccountNumber(accountNumber: String): Boolean
 }

--- a/src/main/kotlin/com/sendy/domain/account/AccountRepository.kt
+++ b/src/main/kotlin/com/sendy/domain/account/AccountRepository.kt
@@ -10,4 +10,6 @@ interface AccountRepository : JpaRepository<AccountEntity, Long> {
         userId: Long,
         accountNumber: String,
     ): AccountEntity?
+
+    fun existsByAccountNumber(accountNumber: String): Boolean
 }

--- a/src/main/kotlin/com/sendy/support/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sendy/support/error/ErrorCode.kt
@@ -11,4 +11,6 @@ enum class ErrorCode(
     NULL_POINT(500, 512, "Null point"),
     NOT_FOUND(404, 404, "찾을 수 없음"),
     INVALID_INPUT_VALUE(400, 400, "유효하지 않은 입력값"),
+    TOO_MANY_REQUESTS(429, 429, "요청이 너무 많습니다"),
+    PASSWORD_ERROR_LIMIT_EXCEEDED(429, 1001, "비밀번호 오류 횟수 초과"),
 }

--- a/src/test/kotlin/com/sendy/domain/service/CreateAccountNumberTest.kt
+++ b/src/test/kotlin/com/sendy/domain/service/CreateAccountNumberTest.kt
@@ -1,0 +1,219 @@
+package com.sendy.domain.service
+
+import com.sendy.application.dto.account.CreateAccountRequest
+import com.sendy.application.usecase.account.command.CreateAccountNumberUseCase
+import com.sendy.application.usecase.account.command.CreateAccountService
+import com.sendy.domain.account.AccountEntity
+import com.sendy.domain.account.AccountRepository
+import com.sendy.domain.account.AccountStatus
+import com.sendy.support.util.getTsid
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("계좌 생성 서비스 테스트")
+class CreateAccountNumberTest {
+
+    @Mock
+    private lateinit var accountRepository: AccountRepository
+
+    @Mock
+    private lateinit var createAccountNumberUseCase: CreateAccountNumberUseCase
+
+    @InjectMocks
+    private lateinit var createAccountService: CreateAccountService
+
+    private lateinit var testRequest: CreateAccountRequest
+    private lateinit var testAccountEntity: AccountEntity
+    private val testUserId = 1L
+    private val testPassword = 1111
+    private val generatedAccountNumber = "3219876543210"
+
+        @BeforeEach
+    fun setUp() {
+        testRequest = CreateAccountRequest(
+            userId = testUserId,
+            password = testPassword,
+            isPrimary = true,
+            isLimitedAccount = false
+        )
+
+        testAccountEntity = AccountEntity(
+            id = getTsid(),
+            accountNumber = generatedAccountNumber,
+            userId = testUserId,
+            password = testPassword,
+            status = AccountStatus.ACTIVE,
+            isPrimary = true,
+            isLimitedAccount = false,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            balance = 0L
+        )
+    }
+
+    @Test
+    @DisplayName("계좌 생성이 성공적으로 완료되어야 한다")
+    fun `계좌 생성 성공 테스트`() {
+        // given
+        `when`(createAccountNumberUseCase.generate()).thenReturn(generatedAccountNumber)
+        `when`(accountRepository.save(any(AccountEntity::class.java))).thenReturn(testAccountEntity)
+
+        // when
+        val result = createAccountService.execute(testRequest)
+
+        // then
+        assertNotNull(result)
+        assertEquals(generatedAccountNumber, result.accountNumber) // 서버에서 생성된 계좌번호
+        verify(createAccountNumberUseCase, times(1)).generate()
+        verify(accountRepository, times(1)).save(any(AccountEntity::class.java))
+    }
+
+    @Test
+    @DisplayName("계좌 생성 시 올바른 AccountEntity가 저장되어야 한다")
+    fun `계좌 생성 시 AccountEntity 검증 테스트`() {
+        // given
+        `when`(createAccountNumberUseCase.generate()).thenReturn(generatedAccountNumber)
+        `when`(accountRepository.save(any(AccountEntity::class.java))).thenReturn(testAccountEntity)
+
+        // when
+        createAccountService.execute(testRequest)
+
+        // then
+        val captor = ArgumentCaptor.forClass(AccountEntity::class.java)
+        verify(accountRepository).save(captor.capture())
+        
+        val savedEntity = captor.value
+        assertEquals(generatedAccountNumber, savedEntity.accountNumber) // 서버에서 생성된 계좌번호
+        assertEquals(testUserId, savedEntity.userId)
+        assertEquals(AccountStatus.ACTIVE, savedEntity.status)
+        assertEquals(true, savedEntity.isPrimary)
+        assertEquals(false, savedEntity.isLimitedAccount)
+        assertEquals(0L, savedEntity.balance)
+        assertNotNull(savedEntity.createdAt)
+        assertNotNull(savedEntity.updatedAt)
+    }
+
+    @Test
+    @DisplayName("계좌 저장이 호출되어야 한다")
+    fun `계좌 저장 호출 테스트`() {
+        // given
+        `when`(createAccountNumberUseCase.generate()).thenReturn(generatedAccountNumber)
+        `when`(accountRepository.save(any(AccountEntity::class.java))).thenReturn(testAccountEntity)
+
+        // when
+        createAccountService.execute(testRequest)
+
+        // then
+        verify(accountRepository, times(1)).save(any(AccountEntity::class.java))
+    }
+
+    @Test
+    @DisplayName("생성된 계좌번호가 321로 시작하는 13자리여야 한다")
+    fun `계좌번호 321 형식 검증 테스트`() {
+        // given
+        `when`(createAccountNumberUseCase.generate()).thenReturn(generatedAccountNumber)
+        `when`(accountRepository.save(any(AccountEntity::class.java))).thenReturn(testAccountEntity)
+
+        // when
+        createAccountService.execute(testRequest)
+
+        // then
+        val captor = ArgumentCaptor.forClass(AccountEntity::class.java)
+        verify(accountRepository).save(captor.capture())
+        
+        val savedEntity = captor.value
+        assertEquals(13, savedEntity.accountNumber.length)
+        assertTrue(savedEntity.accountNumber.all { it.isDigit() })
+        assertTrue(savedEntity.accountNumber.startsWith("321"))
+    }
+
+    @Test
+    @DisplayName("계좌번호가 숫자로만 구성되어야 한다")
+    fun `계좌번호 숫자 검증 테스트`() {
+        // given
+        `when`(createAccountNumberUseCase.generate()).thenReturn(generatedAccountNumber)
+        `when`(accountRepository.save(any(AccountEntity::class.java))).thenReturn(testAccountEntity)
+
+        // when
+        createAccountService.execute(testRequest)
+
+        // then
+        val captor = ArgumentCaptor.forClass(AccountEntity::class.java)
+        verify(accountRepository).save(captor.capture())
+        
+        val savedEntity = captor.value
+        assertTrue(savedEntity.accountNumber.all { it.isDigit() })
+    }
+
+
+
+    @Test
+    @DisplayName("13자리가 아닌 계좌번호는 예외를 발생시켜야 한다")
+    fun `13자리가 아닌 계좌번호 예외 테스트`() {
+        // given
+        val invalidAccountNumber = "123456789012" // 12자리
+        `when`(createAccountNumberUseCase.generate()).thenReturn(invalidAccountNumber)
+
+        // when & then
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            createAccountService.execute(testRequest)
+        }
+        assertEquals("계좌번호는 13자리여야 합니다.", exception.message)
+    }
+
+    @Test
+    @DisplayName("숫자가 아닌 문자가 포함된 계좌번호는 예외를 발생시켜야 한다")
+    fun `숫자가 아닌 문자 포함 계좌번호 예외 테스트`() {
+        // given
+        val invalidAccountNumber = "321123456789A" // 문자 포함
+        `when`(createAccountNumberUseCase.generate()).thenReturn(invalidAccountNumber)
+
+        // when & then
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            createAccountService.execute(testRequest)
+        }
+        assertEquals("계좌번호는 숫자만 가능합니다.", exception.message)
+    }
+
+    @Test
+    @DisplayName("321로 시작하지 않는 계좌번호는 예외를 발생시켜야 한다")
+    fun `321로 시작하지 않는 계좌번호 예외 테스트`() {
+        // given
+        val invalidAccountNumber = "1231234567890" // 321로 시작하지 않음
+        `when`(createAccountNumberUseCase.generate()).thenReturn(invalidAccountNumber)
+
+        // when & then
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            createAccountService.execute(testRequest)
+        }
+        assertEquals("계좌번호는 321로 시작해야 합니다.", exception.message)
+    }
+
+    @Test
+    @DisplayName("빈 문자열 계좌번호는 예외를 발생시켜야 한다")
+    fun `빈 문자열 계좌번호 예외 테스트`() {
+        // given
+        val invalidAccountNumber = ""
+        `when`(createAccountNumberUseCase.generate()).thenReturn(invalidAccountNumber)
+
+        // when & then
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            createAccountService.execute(testRequest)
+        }
+        assertEquals("계좌번호는 13자리여야 합니다.", exception.message)
+    }
+
+
+
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) taks id 번호

계좌 생성 - 계좌 포맷 검토
[SENDY-5-50](https://www.notion.so/240d5beeb0c0803898ffc9b7de5f8a82?v=22ad5beeb0c080bcb9e0000cd480d3f2&source=copy_link)

계좌 비밀번호 생성
[SENDY-5-44](https://www.notion.so/23ed5beeb0c08017b6e4dd98ca4d6be4?v=22ad5beeb0c080bcb9e0000cd480d3f2&source=copy_link)

## 📝작업 내용
이전에는 13자리 계좌 생성을 클라이언트단에서 생성 이후 검증하는 코드 
-> 현재는 서버에서 13자리 계좌 번호를 생성후 검증 하고 생성 방식으로 변경 [기관코드 321 로 시작] 321-xxxx-xx-xxxx 이런식으로 13자리 입니다. 
보통 은행 db에는 하이픈을 빼고 저장하는 방식이여서 하이픈을 빼고 진행 했습니다.

feature 분리 해서 진행하기에는 계좌 비밀번호 생성은 간단하여서 같이 작업했습니다. 
클라단에서 생성된 비밀번호 받아서 처리하는 구조

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

AccountDTO 에서 accountNumber 제거 했습니다.

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?