### PR TITLE
송금 관련 유저 비밀번호 aes256 도입 및 int -> string 으로 변경

### DIFF
--- a/.github/workflows/KoverCI.yml
+++ b/.github/workflows/KoverCI.yml
@@ -1,0 +1,45 @@
+name: Kover CI
+
+on:
+  push:
+    branches:
+      - main        # main 브랜치에 push 시 실행
+  pull_request:     # 모든 브랜치의 PR 이벤트에 실행 (branches 필드 없음)
+
+jobs:
+  build-and-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build and Run tests
+        run: ./gradlew build test
+
+      - name: Generate Kover Coverage Report (XML)
+        run: ./gradlew koverXmlReport
+
+      - name: Generate Kover Coverage Report (HTML)
+        run: ./gradlew koverReport
+
+      - name: Add coverage report to PR
+        if: github.event_name == 'pull_request'
+        uses: mi-kas/kover-report@v1
+        with:
+          path: ${{ github.workspace }}/build/reports/kover/report.xml
+          title: "Code Coverage Report"
+          update-comment: true
+          min-coverage-overall: 70
+          min-coverage-changed-files: 70
+          coverage-counter-type: LINE

--- a/src/main/kotlin/com/sendy/application/dto/account/CreateAccountDto.kt
+++ b/src/main/kotlin/com/sendy/application/dto/account/CreateAccountDto.kt
@@ -5,7 +5,7 @@ data class CreateAccountRequest(
     val userId: Long,
     val isPrimary: Boolean,
     val isLimitedAccount: Boolean,
-    val password: Int,
+    val password: String,
 )
 
 data class CreateAccountResponse(

--- a/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountService.kt
+++ b/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountService.kt
@@ -7,6 +7,7 @@ import com.sendy.domain.account.AccountRepository
 import com.sendy.domain.account.AccountStatus
 import com.sendy.support.util.getTsid
 import com.sendy.support.util.AccountNumberValidator
+import com.sendy.support.util.Aes256Util
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -15,7 +16,8 @@ import java.time.LocalDateTime
 @Service
 class CreateAccountService(
     private val accountRepository: AccountRepository,
-    private val createAccountNumberUseCase: CreateAccountNumberUseCase
+    private val createAccountNumberUseCase: CreateAccountNumberUseCase,
+    private val Aes256Util: Aes256Util
 ) : CreateAccountUseCase {
     override fun execute(request: CreateAccountRequest): CreateAccountResponse {
         // 서버에서 계좌번호를 자동 생성
@@ -23,14 +25,14 @@ class CreateAccountService(
         
         // 생성된 계좌번호 형식 검증 (321-xxxx-xx-xxxx 형식)
         AccountNumberValidator.validateFormat(generatedAccountNumber)
-
+        val encryptedPassword = Aes256Util.encrypt(request.password)
         return accountRepository
             .save(
                 AccountEntity(
                     id = getTsid(),
                     accountNumber = generatedAccountNumber, // 서버에서 생성한 계좌번호 사용
                     userId = request.userId,
-                    password = request.password, // 클라이언트에서 받은 비밀번호
+                    password = encryptedPassword, // 클라이언트에서 받은 비밀번호
                     status = AccountStatus.ACTIVE,
                     isPrimary = request.isPrimary,
                     isLimitedAccount = request.isLimitedAccount,

--- a/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountService.kt
+++ b/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountService.kt
@@ -2,46 +2,15 @@ package com.sendy.application.usecase.account.command
 
 import com.sendy.application.dto.account.CreateAccountRequest
 import com.sendy.application.dto.account.CreateAccountResponse
-import com.sendy.domain.account.AccountEntity
-import com.sendy.domain.account.AccountRepository
-import com.sendy.domain.account.AccountStatus
-import com.sendy.support.util.getTsid
-import com.sendy.support.util.AccountNumberValidator
-import com.sendy.support.util.Aes256Util
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Transactional
 @Service
 class CreateAccountService(
-    private val accountRepository: AccountRepository,
-    private val createAccountNumberUseCase: CreateAccountNumberUseCase,
-    private val Aes256Util: Aes256Util
+    private val createAccountUseCase: CreateAccountUseCaseImpl
 ) : CreateAccountUseCase {
     override fun execute(request: CreateAccountRequest): CreateAccountResponse {
-        // 서버에서 계좌번호를 자동 생성
-        val generatedAccountNumber = createAccountNumberUseCase.generate()
-        
-        // 생성된 계좌번호 형식 검증 (321-xxxx-xx-xxxx 형식)
-        AccountNumberValidator.validateFormat(generatedAccountNumber)
-        val encryptedPassword = Aes256Util.encrypt(request.password)
-        return accountRepository
-            .save(
-                AccountEntity(
-                    id = getTsid(),
-                    accountNumber = generatedAccountNumber, // 서버에서 생성한 계좌번호 사용
-                    userId = request.userId,
-                    password = encryptedPassword, // 클라이언트에서 받은 비밀번호
-                    status = AccountStatus.ACTIVE,
-                    isPrimary = request.isPrimary,
-                    isLimitedAccount = request.isLimitedAccount,
-                    createdAt = LocalDateTime.now(),
-                    updatedAt = LocalDateTime.now(),
-                    balance = 0L,
-                ),
-            ).let {
-                CreateAccountResponse(it.accountNumber)
-            }
+        return createAccountUseCase.execute(request)
     }
 }

--- a/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountUseCaseImpl.kt
+++ b/src/main/kotlin/com/sendy/application/usecase/account/command/CreateAccountUseCaseImpl.kt
@@ -1,0 +1,45 @@
+package com.sendy.application.usecase.account.command
+
+import com.sendy.application.dto.account.CreateAccountRequest
+import com.sendy.application.dto.account.CreateAccountResponse
+import com.sendy.domain.account.AccountEntity
+import com.sendy.domain.account.AccountRepository
+import com.sendy.domain.account.AccountStatus
+import com.sendy.support.util.AccountNumberValidator
+import com.sendy.support.util.Aes256Util
+import com.sendy.support.util.getTsid
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class CreateAccountUseCaseImpl (
+    private val accountRepository: AccountRepository,
+    private val createAccountNumberUseCase: CreateAccountNumberUseCase,
+    private val Aes256Util: Aes256Util
+) : CreateAccountUseCase {
+    override fun execute(request: CreateAccountRequest): CreateAccountResponse {
+        // 서버에서 계좌번호를 자동 생성
+        val generatedAccountNumber = createAccountNumberUseCase.generate()
+
+        // 생성된 계좌번호 형식 검증 (321-xxxx-xx-xxxx 형식)
+        AccountNumberValidator.validateFormat(generatedAccountNumber)
+        val encryptedPassword = Aes256Util.encrypt(request.password)
+        return accountRepository
+            .save(
+                AccountEntity(
+                    id = getTsid(),
+                    accountNumber = generatedAccountNumber, // 서버에서 생성한 계좌번호 사용
+                    userId = request.userId,
+                    password = encryptedPassword, // 클라이언트에서 받은 비밀번호
+                    status = AccountStatus.ACTIVE,
+                    isPrimary = request.isPrimary,
+                    isLimitedAccount = request.isLimitedAccount,
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now(),
+                    balance = 0L,
+                ),
+            ).let {
+                CreateAccountResponse(it.accountNumber)
+            }
+    }
+}

--- a/src/main/kotlin/com/sendy/domain/account/AccountEntity.kt
+++ b/src/main/kotlin/com/sendy/domain/account/AccountEntity.kt
@@ -25,7 +25,7 @@ class AccountEntity(
     @Column(name = "user_id", nullable = false)
     val userId: Long,
     @Column(name = "password", nullable = false, length = 4)
-    val password: Int,
+    val password: String,
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     var status: AccountStatus,

--- a/src/main/kotlin/com/sendy/support/util/Aes256Util.kt
+++ b/src/main/kotlin/com/sendy/support/util/Aes256Util.kt
@@ -1,11 +1,13 @@
 package com.sendy.support.util
 
+import org.springframework.stereotype.Component
 import java.security.SecureRandom
 import java.util.Base64
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
+@Component
 class Aes256Util(key: String) {
     private val secretKey: SecretKeySpec
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> [5-63](https://www.notion.so/1-245d5beeb0c08038a425ef49a003b213?source=copy_link)

## 📝작업 내용

> 송금 관련 유저 비밀번호 aes256 도입 및 int -> string 으로 변경
송금 usecase 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?