### PR TITLE
비밀번호 sha256 -> sha256 + salt 기능으로 추가 구현했습니다.

### DIFF
--- a/docker-compose/mysql/initdb.d/create-table.sql
+++ b/docker-compose/mysql/initdb.d/create-table.sql
@@ -53,7 +53,7 @@ CREATE TABLE transaction_history
 CREATE TABLE users
 (
     id             BIGINT       NOT NULL PRIMARY KEY,
-    password       VARCHAR(100) NOT NULL,
+    password       VARCHAR(120) NOT NULL,
     name           VARCHAR(50)  NOT NULL,
     phone_number   VARCHAR(20)  NOT NULL,
     email          VARCHAR(255) NOT NULL,
@@ -84,7 +84,7 @@ CREATE TABLE account
     id                 BIGINT      NOT NULL PRIMARY KEY,
     account_number     VARCHAR(13) NOT NULL,
     user_id            BIGINT      NOT NULL,
-    password           VARCHAR(64) NOT NULL,
+    password           VARCHAR(120) NOT NULL,
     status             VARCHAR(20) NOT NULL,
     created_at         DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at         DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/main/kotlin/com/sendy/application/usecase/auth/command/VerifyUserCredentialsImpl.kt
+++ b/src/main/kotlin/com/sendy/application/usecase/auth/command/VerifyUserCredentialsImpl.kt
@@ -29,9 +29,8 @@ class VerifyUserCredentialsImpl(
             throw ServiceException(ErrorCode.INVALID_INPUT_VALUE, "로그인할 수 없는 사용자입니다")
         }
 
-        // SHA-256 해시로 비밀번호 검증
-        val hashedPassword = sha256Util.hash(password)
-        if (!userEntity.validatePassword(hashedPassword)) {
+        // SHA-256 + Salt 해시로 비밀번호 검증
+        if (!sha256Util.matches(password, userEntity.password)) {
             throw ServiceException(ErrorCode.INVALID_INPUT_VALUE, "비밀번호가 일치하지 않습니다")
         }
 

--- a/src/main/kotlin/com/sendy/domain/account/AccountEntity.kt
+++ b/src/main/kotlin/com/sendy/domain/account/AccountEntity.kt
@@ -24,7 +24,7 @@ class AccountEntity(
     val accountNumber: String,
     @Column(name = "user_id", nullable = false)
     val userId: Long,
-    @Column(name = "password", nullable = false, length = 64)
+    @Column(name = "password", nullable = false, length = 120)
     val password: String,
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)

--- a/src/main/kotlin/com/sendy/support/util/SHA256Util.kt
+++ b/src/main/kotlin/com/sendy/support/util/SHA256Util.kt
@@ -2,6 +2,9 @@ package com.sendy.support.util
 
 import org.springframework.stereotype.Component
 import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+import java.nio.charset.StandardCharsets
 
 /**
  * SHA-256 해시 유틸리티
@@ -9,23 +12,111 @@ import java.security.MessageDigest
 
 @Component
 class SHA256Util {
+
+    companion object {
+        private const val SALT_LENGTH = 32 // 32바이트 salt
+        private const val SEPARATOR = ":"
+    }
+
+    private fun generateSalt(): ByteArray {
+        val salt = ByteArray(SALT_LENGTH)
+        SecureRandom().nextBytes(salt)
+        return salt
+    }
+    
+    private fun ByteArray.toHex(): String = 
+        joinToString("") { "%02x".format(it) }
+
+    private fun ByteArray.toBase64(): String = 
+        Base64.getEncoder().encodeToString(this)
+
+    private fun sha256WithSalt(password: String, salt: ByteArray): ByteArray {
+        val md = MessageDigest.getInstance("SHA-256")
+        md.update(salt)
+        md.update(password.toByteArray(StandardCharsets.UTF_8))
+        return md.digest()
+    }
+
+    data class StoredHash(
+        val alg: String,
+        val iterations: Int,
+        val saltB64: String,
+        val hashB64: String
+    )
+     
+    fun createSha256Record(password: String): StoredHash {
+        val salt = generateSalt()
+        val hash = sha256WithSalt(password, salt)
+        return StoredHash("SHA256", 0, salt.toBase64(), hash.toBase64())
+    }
+
+    fun verify(inputPassword: String, record: StoredHash): Boolean {
+        val salt = Base64.getDecoder().decode(record.saltB64)
+        val expected = Base64.getDecoder().decode(record.hashB64)
+       
+        val actual = when(record.alg) {
+            "SHA256" -> sha256WithSalt(inputPassword, salt)
+            else -> error("Unknown alg: ${record.alg}")
+        }
+        return constantTimeEquals(actual, expected)
+    }
+
+    private fun constantTimeEquals(a: ByteArray?, b: ByteArray?): Boolean {
+        if (a == null || b == null) return false
+        if (a.size != b.size) return false
+        var r = 0
+        for (i in a.indices) r = r or (a[i].toInt() xor b[i].toInt())
+        return r == 0
+    }
+
+   
+    
     /**
-     * 문자열을 SHA-256으로 해시
+     * 기본 해시 메서드 (Salt 포함)
+     * 반환 형식: "base64Salt:hexHash"
      */
     fun hash(input: String): String {
+        val salt = generateSalt()
+        val hash = sha256WithSalt(input, salt)
+        return "${salt.toBase64()}$SEPARATOR${hash.toHex()}"
+    }
+    
+    /**
+     * 비밀번호 검증 (하위 호환성 지원)
+     */
+    fun matches(rawValue: String, storedHash: String): Boolean {
+        return if (storedHash.contains(SEPARATOR)) {
+            // 새로운 Salt 방식
+            val parts = storedHash.split(SEPARATOR)
+            if (parts.size != 2) return false
+            
+            try {
+                val salt = Base64.getDecoder().decode(parts[0])
+                val expectedHashHex = parts[1]
+                val actualHash = sha256WithSalt(rawValue, salt)
+                val actualHashHex = actualHash.toHex()
+                actualHashHex == expectedHashHex
+            } catch (e: Exception) {
+                false
+            }
+        } else {
+            // 기존 방식 (하위 호환성)
+            hashLegacy(rawValue) == storedHash
+        }
+    }
+    
+    /**
+     * 기존 방식의 해시 (하위 호환성용)
+     */
+    private fun hashLegacy(input: String): String {
         val digest = MessageDigest.getInstance("SHA-256")
         val hashBytes = digest.digest(input.toByteArray())
         return hashBytes.joinToString("") { "%02x".format(it) }
     }
-
+    
     /**
      * 고정된 해시 생성 (디바이스 핑거프린트용)
-     * 같은 입력에 대해 항상 같은 결과를 보장
+     * 같은 입력에 대해 항상 같은 결과를 보장 (Salt 사용 안함)
      */
-    fun createFixedHash(input: String): String = hash(input)
-
-    fun matches(
-        rawValue: String,
-        hashValue: String,
-    ) = hash(rawValue) == hashValue
+    fun createFixedHash(input: String): String = hashLegacy(input)
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) [SENDY-5-69](https://www.notion.so/salt-sha256-24dd5beeb0c0800fb9f8d66be5fcec1f?v=22ad5beeb0c080bcb9e0000cd480d3f2&source=copy_link)

## 📝작업 내용
기존 비밀번호 암호화 SHA256 만 사용 
현재 비밀번호 암호화 SHA256 + salt 로 로직 변경 
기존 테이블 길이 100 -> 120으로 변경

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?