### PR TITLE
도커에 몽고디비 관련 파일 설정올렸습니다.

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -112,6 +112,24 @@ services:
     networks:
       - sendy-net
 
+  mongo:
+    image: mongo:8.0
+    container_name: sendy-mongodb
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: sendy-mongoDB
+      MONGO_INITDB_ROOT_PASSWORD: sendy123!
+      # 기본 데이터베이스 생성
+      MONGO_INITDB_DATABASE: notification
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./db/mongo:/data/db
+      - ./db/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    networks:
+      - sendy-net
+
+
 networks:
   sendy-net:
 

--- a/sendy-notification-api/build.gradle.kts
+++ b/sendy-notification-api/build.gradle.kts
@@ -1,0 +1,18 @@
+group = "com.sendy.sendy-notification-api"
+version = "0.0.1-SNAPSHOT"
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.Embeddable")
+    annotation("jakarta.persistence.MappedSuperclass")
+}
+
+tasks.bootJar {
+    archiveFileName.set("sendy-notification-api.jar")
+}
+
+dependencies {
+    //MongoDB 공통 모듈 (알림 조회용)
+    implementation(project(":sendy-shared-mongoDB"))
+    implementation("org.springframework.boot:spring-boot-starter-web")
+}

--- a/sendy-notification-api/src/main/kotlin/com/sendy/Notification.kt
+++ b/sendy-notification-api/src/main/kotlin/com/sendy/Notification.kt
@@ -1,0 +1,22 @@
+package com.sendy
+
+import java.time.Instant
+
+class Notification(
+    var id:String,
+    var userId:Long,
+    var type:NotificationType,
+    var createdAt: Instant,
+    var deletedAt: Instant?,
+){
+
+    enum class NotificationType {
+        REGISTER, //회원가입
+        TRANSFER, //송금
+        PW_CHANGED, //비밀번호 변경
+        ACCOUNT_CREATED, //계좌 생성
+        ACCOUNT_DELETED, //계좌 삭제
+
+    }
+
+}

--- a/sendy-notification-api/src/main/kotlin/com/sendy/application/usecase/command/NotificationRepository.kt
+++ b/sendy-notification-api/src/main/kotlin/com/sendy/application/usecase/command/NotificationRepository.kt
@@ -1,0 +1,11 @@
+package com.sendy.application.usecase.command
+
+import com.sendy.Notification
+
+interface NotificationRepository {
+    fun findById(id:String): Notification?
+
+    fun save(notification: Notification)
+
+    fun delete(id: String)
+}

--- a/sendy-notification-consumer/build.gradle.kts
+++ b/sendy-notification-consumer/build.gradle.kts
@@ -1,0 +1,24 @@
+group = "com.sendy.sendy-notification-consumer"
+version = "0.0.1-SNAPSHOT"
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.Embeddable")
+    annotation("jakarta.persistence.MappedSuperclass")
+}
+
+tasks.bootJar {
+    archiveFileName.set("sendy-notification-consumer.jar")
+}
+
+dependencies {
+    //MongoDB 공통 모듈 (알림 저장용)
+    implementation(project(":sendy-shared-mongoDB"))
+    
+    // Kafka 공통 모듈 (이벤트 수신용) 
+    implementation(project(":sendy-shared-kafka"))
+    
+    // Web 및 Kafka 의존성
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.kafka:spring-kafka")
+}

--- a/sendy-notification-producer/build.gradle.kts
+++ b/sendy-notification-producer/build.gradle.kts
@@ -1,0 +1,2 @@
+group = "com.sendy"
+version = "0.0.1-SNAPSHOT"

--- a/sendy-shared-mongoDB/build.gradle.kts
+++ b/sendy-shared-mongoDB/build.gradle.kts
@@ -1,0 +1,20 @@
+group = "com.sendy.sendy-shared-mongoDB"
+version = "0.0.1-SNAPSHOT"
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.Embeddable")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("org.springframework.data.mongodb.core.mapping.Document")
+}
+
+dependencies {
+    // MongoDB 관련 의존성을 다른 모듈에 제공
+    api("org.springframework.boot:spring-boot-starter-data-mongodb")
+    api("org.springframework.boot:spring-boot-starter-web")
+    api("com.fasterxml.jackson.module:jackson-module-kotlin")
+
+    // 테스트용 (라이브러리 내부에서만 사용)
+    testImplementation("org.testcontainers:testcontainers:1.24.0")
+    testImplementation("org.testcontainers:mongodb:1.24.0")
+}

--- a/sendy-shared-mongoDB/src/main/kotlin/com/sendy/config/MongoConfig.kt
+++ b/sendy-shared-mongoDB/src/main/kotlin/com/sendy/config/MongoConfig.kt
@@ -1,0 +1,16 @@
+package com.sendy.config
+
+import org.springframework.context.annotation.Configuration
+
+/**
+ * MongoDB 자동 구성
+ * 
+ * Spring Boot가 application.yml의 설정을 자동으로 읽어서
+ * MongoClient와 MongoTemplate Bean을 자동 생성합니다.
+ * 
+ * 별도의 @Bean 정의가 불필요합니다!
+ */
+@Configuration
+class MongoConfig {
+
+}

--- a/sendy-shared-mongoDB/src/main/kotlin/com/sendy/config/MongoTemplateConfig.kt
+++ b/sendy-shared-mongoDB/src/main/kotlin/com/sendy/config/MongoTemplateConfig.kt
@@ -1,0 +1,17 @@
+package com.sendy.config
+
+import org.springframework.context.annotation.Configuration
+
+/**
+ * MongoDB 설정
+ * Spring Boot가 application.yml 설정을 자동으로 읽어서 
+ * MongoClient와 MongoTemplate을 자동 구성합니다.
+ * 
+ * 별도 @Bean 정의가 필요없슴
+ */
+@Configuration
+class MongoTemplateConfig {
+
+}
+
+

--- a/sendy-shared-mongoDB/src/main/resources/application-secure.yml
+++ b/sendy-shared-mongoDB/src/main/resources/application-secure.yml
@@ -1,0 +1,42 @@
+# 보안이 강화된 MongoDB 설정 (애플리케이션 전용 사용자)
+
+# 기본 설정 (Docker 내부)
+spring:
+  data:
+    mongodb:
+      host: mongo
+      port: 27017
+      database: notification
+      username: notification-user  # 초기화 스크립트에서 생성한 사용자
+      password: notification123
+      authentication-database: notification  # notification DB로 인증
+
+---
+# 로컬 개발 환경
+spring:
+  config:
+    activate:
+      on-profile: local
+  data:
+    mongodb:
+      host: localhost
+      port: 27017
+      database: notification_local
+      username: notification-user
+      password: notification123
+      authentication-database: notification
+
+---  
+# Docker 내부 환경
+spring:
+  config:
+    activate:
+      on-profile: docker
+  data:
+    mongodb:
+      host: mongo
+      port: 27017
+      database: notification
+      username: notification-user
+      password: notification123
+      authentication-database: notification

--- a/sendy-shared-mongoDB/src/main/resources/application.yml
+++ b/sendy-shared-mongoDB/src/main/resources/application.yml
@@ -1,0 +1,64 @@
+# MongoDB Docker 기본 설정
+spring:
+  data:
+    mongodb:
+      # 별도 설정으로 인증 (URL 인코딩 문제 해결)
+      host: mongo
+      port: 27017
+      database: notification
+      username: sendy-mongoDB
+      password: sendy123!
+      authentication-database: admin
+
+# 로그 설정 (선택사항)  
+logging:
+  level:
+    org.springframework.data.mongodb: DEBUG
+    org.mongodb.driver: INFO
+
+---
+# 로컬 개발 환경 (Docker 외부에서 접근)
+spring:
+  config:
+    activate:
+      on-profile: local
+  data:
+    mongodb:
+      # 로컬에서 Docker MongoDB에 접근
+      host: localhost
+      port: 27017
+      database: notification_local
+      username: sendy-mongoDB
+      password: sendy123!
+      authentication-database: admin
+
+---
+# Docker Compose 내부 환경
+spring:
+  config:
+    activate:
+      on-profile: docker
+  data:
+    mongodb:
+      # Docker 컨테이너 간 통신 (내부 네트워크)
+      host: mongo
+      port: 27017
+      database: notification
+      username: sendy-mongoDB
+      password: sendy123!
+      authentication-database: admin
+
+---
+# 운영 환경
+spring:
+  config:
+    activate:
+      on-profile: prod
+  data:
+    mongodb:
+      host: ${MONGODB_HOST:mongo}
+      port: ${MONGODB_PORT:27017}
+      database: ${MONGODB_DATABASE:notification}
+      username: ${MONGODB_USERNAME:sendy-mongoDB}
+      password: ${MONGODB_PASSWORD:sendy123!}
+      authentication-database: ${MONGODB_AUTH_DATABASE:admin}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,12 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
 rootProject.name = "sendy"
 
 // application
 include("sendy-legacy-api", "sendy-shared-kafka")
+include("sendy-notification-api")
+include("sendy-notification-consumer")
+include("sendy-notification-producer")
+include("sendy-shared-mongoDB")
+include("sendy-notificaiton-mongoDB")


### PR DESCRIPTION
알림 관련 서비스 모듈화
sendy-notification-api [알림 조회 및 응답]
sendy-notification-comsumer [ 이벤트 수신 시 분기처리 하여 디비에 저장 ]
sendy-notification-producer [ 좀 애매합니다. sendy-legacy-api 에서 각각 producer를 발행하고있어서... 단 추후에 legacy-api 가 분리가 된다면 producer로 전용 알림 발행 서비스로 활용이 가능할거같습니다.]
sendy-shared-mongodb

추가하였습니다.

## #️⃣연관된 이슈

> [sendy-5-71](https://www.notion.so/ADR-24dd5beeb0c080fe9eb6dbda4b6f5597?source=copy_link)

## 📝작업 내용

> 알림 기능 모듈화 하여서 추가하였습니다. 
sendy-legacy-api 에서 api 던지면 이벤트발행하여서 sendy-notification-producer에 producer를 사용해서 단일 토픽 -> 
sendy-notification-consumer 에서 이벤트 타입 분기처리로 각 데이터를 sendy-shared-mogodb에 값을 저장한다.
sendy-notification-api 에서는 알림 데이터를 읽고 응답 하는 기능


<img width="2613" height="1564" alt="image" src="https://github.com/user-attachments/assets/9920cc37-b4a0-4726-8ee5-4160fb35dbd5" />

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?